### PR TITLE
Battery size and mass

### DIFF
--- a/greenheart/tools/eco/hydrogen_mgmt.py
+++ b/greenheart/tools/eco/hydrogen_mgmt.py
@@ -496,8 +496,8 @@ def run_equipment_platform(
             toparea += h2_storage_results["tank_footprint_m2"]
 
         if hopp_config["site"]["solar"]:
-            solar_area = hopp_results['hybrid_plant'].pv.plant_area
-            solar_mass = hopp_results['hybrid_plant'].pv.plant_mass
+            solar_area = hopp_results['hybrid_plant'].pv.system_area
+            solar_mass = hopp_results['hybrid_plant'].pv.system_mass
             
             if solar_area > toparea:
                 raise(ValueError(f"Solar area ({solar_area} m^2) is larger than platform area ({toparea})"))

--- a/greenheart/tools/eco/hydrogen_mgmt.py
+++ b/greenheart/tools/eco/hydrogen_mgmt.py
@@ -496,7 +496,7 @@ def run_equipment_platform(
             toparea += h2_storage_results["tank_footprint_m2"]
 
         if hopp_config["site"]["solar"]:
-            solar_area = hopp_results['hybrid_plant'].pv.system_area
+            solar_area = hopp_results['hybrid_plant'].pv.footprint_area
             solar_mass = hopp_results['hybrid_plant'].pv.system_mass
             
             if solar_area > toparea:

--- a/greenheart/tools/eco/utilities.py
+++ b/greenheart/tools/eco/utilities.py
@@ -791,7 +791,7 @@ def visualize_plant(
     ## add solar
     if hopp_config["site"]["solar"]:
         solar_side_y = equipment_platform_side_length
-        solar_side_x = hopp_results["hybrid_plant"].pv.system_area/solar_side_y
+        solar_side_x = hopp_results["hybrid_plant"].pv.footprint_area/solar_side_y
 
         solarx = equipment_platform_x - equipment_platform_side_length / 2
         solary = equipment_platform_y - equipment_platform_side_length / 2

--- a/greenheart/tools/eco/utilities.py
+++ b/greenheart/tools/eco/utilities.py
@@ -791,7 +791,7 @@ def visualize_plant(
     ## add solar
     if hopp_config["site"]["solar"]:
         solar_side_y = equipment_platform_side_length
-        solar_side_x = hopp_results["hybrid_plant"].pv.plant_area/solar_side_y
+        solar_side_x = hopp_results["hybrid_plant"].pv.system_area/solar_side_y
 
         solarx = equipment_platform_x - equipment_platform_side_length / 2
         solary = equipment_platform_y - equipment_platform_side_length / 2

--- a/hopp/simulation/technologies/battery/battery.py
+++ b/hopp/simulation/technologies/battery/battery.py
@@ -235,8 +235,8 @@ class Battery(PowerSource):
         return self._system_model.ParamsPack.mass
 
     @property
-    def system_size(self) -> float:
-        """Battery bank size [m^2]"""
+    def footprint_area(self) -> float:
+        """Battery bank footprint area [m^2]"""
         #Battery thermal model assumes a cube for heat exchange
         cube_surface_area = self._system_model.ParamsPack.surface_area 
         footprint = cube_surface_area / 6 # Single side of cube

--- a/hopp/simulation/technologies/battery/battery.py
+++ b/hopp/simulation/technologies/battery/battery.py
@@ -228,7 +228,20 @@ class Battery(PowerSource):
             return self._chemistry
         else:
             raise ValueError("chemistry model type unrecognized")
-        
+
+    @property    
+    def system_mass(self) -> float:
+        """Battery bank mass [kg]"""
+        return self._system_model.ParamsPack.mass
+
+    @property
+    def system_size(self) -> float:
+        """Battery bank size [m^2]"""
+        #Battery thermal model assumes a cube for heat exchange
+        cube_surface_area = self._system_model.ParamsPack.surface_area 
+        footprint = cube_surface_area / 6 # Single side of cube
+        return footprint
+
     @property
     def energy_capital_cost(self) -> Union[float, int]:
         """The capital cost per unit of energy capacity [$/kWh] for battery storage technology """

--- a/hopp/simulation/technologies/pv/pv_plant.py
+++ b/hopp/simulation/technologies/pv/pv_plant.py
@@ -183,8 +183,8 @@ class PVPlant(PowerSource):
             raise NotImplementedError("Module type not set")
 
     @property
-    def system_area(self):
-        """Estimate Total Module Area [m^2]"""
+    def footprint_area(self):
+        """Estimate Total Module Footprint Area [m^2]"""
         module_attribs = get_module_attribs(self._system_model)
         num_modules = self.system_capacity_kw / module_attribs['P_mp_ref']
         area = num_modules * module_attribs['area']
@@ -193,7 +193,7 @@ class PVPlant(PowerSource):
     @property
     def system_mass(self):
         """Estimate Total Module Mass [kg]"""
-        return self.system_area * self.module_unit_mass
+        return self.footprint_area * self.module_unit_mass
 
     @property
     def capacity_factor(self) -> float:

--- a/hopp/simulation/technologies/pv/pv_plant.py
+++ b/hopp/simulation/technologies/pv/pv_plant.py
@@ -183,17 +183,17 @@ class PVPlant(PowerSource):
             raise NotImplementedError("Module type not set")
 
     @property
-    def plant_area(self):
-        """Estimate Total Module Area [m2]"""
+    def system_area(self):
+        """Estimate Total Module Area [m^2]"""
         module_attribs = get_module_attribs(self._system_model)
         num_modules = self.system_capacity_kw / module_attribs['P_mp_ref']
         area = num_modules * module_attribs['area']
         return  area
 
     @property
-    def plant_mass(self):
+    def system_mass(self):
         """Estimate Total Module Mass [kg]"""
-        return self.plant_area * self.module_unit_mass
+        return self.system_area * self.module_unit_mass
 
     @property
     def capacity_factor(self) -> float:

--- a/tests/hopp/test_battery.py
+++ b/tests/hopp/test_battery.py
@@ -81,3 +81,9 @@ def test_battery_initialization(site, subtests):
         battery = Battery(site, config=config)
 
         assert battery._financial_model == fin_model
+
+    with subtests.test("battery mass"):
+        assert battery.system_mass == pytest.approx(304454.0,1e-3) #TODO: verify system mass. Current value is just based on output at writing.
+
+    with subtests.test("battery area"):
+        assert battery.system_size == pytest.approx(250.0, 1e-3) #TODO: verify system mass. Current value is just based on output at writing.

--- a/tests/hopp/test_battery.py
+++ b/tests/hopp/test_battery.py
@@ -85,5 +85,5 @@ def test_battery_initialization(site, subtests):
     with subtests.test("battery mass"):
         assert battery.system_mass == pytest.approx(304454.0,1e-3) #TODO: verify system mass. Current value is just based on output at writing.
 
-    with subtests.test("battery area"):
-        assert battery.system_size == pytest.approx(250.0, 1e-3) #TODO: verify system mass. Current value is just based on output at writing.
+    with subtests.test("battery footprint area"):
+        assert battery.footprint_area == pytest.approx(250.0, 1e-3) #TODO: verify system mass. Current value is just based on output at writing.

--- a/tests/hopp/test_hybrid.py
+++ b/tests/hopp/test_hybrid.py
@@ -317,6 +317,7 @@ def test_hybrid_pv_battery_custom_fin(hybrid_config, subtests):
     tech = {
         'pv': {
             'system_capacity_kw': 5000,
+            'installed_capital_cost_per_kw': 400,
             'layout_params': {
                 'x_position': 0.5,
                 'y_position': 0.5,
@@ -331,6 +332,8 @@ def test_hybrid_pv_battery_custom_fin(hybrid_config, subtests):
           'battery': {
             'system_capacity_kw': 5000,
             'system_capacity_kwh': 20000,
+            'energy_capital_cost':300,
+            'power_capital_cost':200,
             'fin_model': DEFAULT_FIN_CONFIG
           },
         'grid':{
@@ -342,8 +345,8 @@ def test_hybrid_pv_battery_custom_fin(hybrid_config, subtests):
     hi = HoppInterface(hybrid_config)
 
     hybrid_plant = hi.system
-    hybrid_plant.pv.set_overnight_capital_cost(400)
-    hybrid_plant.battery.set_overnight_capital_cost(300,200)
+    # hybrid_plant.pv.set_overnight_capital_cost(400)
+    # hybrid_plant.battery.set_overnight_capital_cost(300,200)
     hybrid_plant.set_om_costs_per_kw(pv_om_per_kw=20,battery_om_per_kw=30)
 
     hi.simulate()

--- a/tests/hopp/test_pv_source.py
+++ b/tests/hopp/test_pv_source.py
@@ -68,7 +68,7 @@ def test_pv_plant_area(site, subtests):
     pv_plant = PVPlant(site=site, config=config)
     
     with subtests.test("plant area"):
-        assert pv_plant.plant_area == pytest.approx(457.94, 0.1)
+        assert pv_plant.system_area == pytest.approx(457.94, 0.1)
 
 def test_pv_plant_mass(site, subtests):
     system_capacity_kw = 100.0
@@ -78,4 +78,4 @@ def test_pv_plant_mass(site, subtests):
     pv_plant = PVPlant(site=site, config=config)
 
     with subtests.test("plant mass"):
-        assert pv_plant.plant_mass == pytest.approx(5079.51,0.01)
+        assert pv_plant.system_mass == pytest.approx(5079.51,0.01)

--- a/tests/hopp/test_pv_source.py
+++ b/tests/hopp/test_pv_source.py
@@ -67,8 +67,8 @@ def test_pv_plant_area(site, subtests):
 
     pv_plant = PVPlant(site=site, config=config)
     
-    with subtests.test("plant area"):
-        assert pv_plant.system_area == pytest.approx(457.94, 0.1)
+    with subtests.test("plant footprint area"):
+        assert pv_plant.footprint_area == pytest.approx(457.94, 0.1)
 
 def test_pv_plant_mass(site, subtests):
     system_capacity_kw = 100.0


### PR DESCRIPTION
- Added Battery footprint area [m^2]: `footprint_area`
- Added Battery system mass [kg]: `system_mass`
- Updated test_battery with size and mass tests
- Changed PV size and mass to same name convention as battery: from `plant_mass` --> `system_mass`. `plant_size` --> `footprint_area`
- Updated test_hybrid with costs in config
- Updated calls in eco tools with new PV system size and mass naming convention